### PR TITLE
Restrict deposit sender

### DIFF
--- a/contracts/agent/aibtc-agent-account.clar
+++ b/contracts/agent/aibtc-agent-account.clar
@@ -53,7 +53,7 @@
 
 ;; public functions
 
-;; anyone can deposit STX to this contract
+;; the owner or agent can deposit STX to this contract
 (define-public (deposit-stx (amount uint))
   (begin
     (asserts! (is-owner-or-agent-sender) ERR_OPERATION_NOT_ALLOWED)
@@ -70,7 +70,7 @@
   )
 )
 
-;; anyone can deposit FT to this contract if the asset contract is approved
+;; the owner or agent can deposit FT to this contract if the asset contract is approved
 (define-public (deposit-ft
     (ft <ft-trait>)
     (amount uint)

--- a/contracts/agent/aibtc-agent-account.clar
+++ b/contracts/agent/aibtc-agent-account.clar
@@ -47,8 +47,8 @@
 )
 
 ;; data vars
-(define-data-var agentCanUseProposals bool false)
-(define-data-var agentCanApproveRevokeContracts bool false)
+(define-data-var agentCanUseProposals bool true)
+(define-data-var agentCanApproveRevokeContracts bool true)
 (define-data-var agentCanBuySellAssets bool false)
 
 ;; public functions

--- a/contracts/agent/aibtc-agent-account.clar
+++ b/contracts/agent/aibtc-agent-account.clar
@@ -56,6 +56,7 @@
 ;; anyone can deposit STX to this contract
 (define-public (deposit-stx (amount uint))
   (begin
+    (asserts! (is-owner-or-agent-sender) ERR_OPERATION_NOT_ALLOWED)
     (print {
       notification: "aibtc-agent-account/deposit-stx",
       payload: {
@@ -75,6 +76,7 @@
     (amount uint)
   )
   (begin
+    (asserts! (is-owner-or-agent-sender) ERR_OPERATION_NOT_ALLOWED)
     (asserts! (is-approved-contract (contract-of ft)) ERR_CONTRACT_NOT_APPROVED)
     (print {
       notification: "aibtc-agent-account/deposit-ft",
@@ -390,6 +392,13 @@
 
 (define-private (is-agent)
   (is-eq contract-caller ACCOUNT_AGENT)
+)
+
+(define-private (is-owner-or-agent-sender)
+  (or
+    (is-eq tx-sender ACCOUNT_OWNER)
+    (is-eq tx-sender ACCOUNT_AGENT)
+  )
 )
 
 (define-private (use-proposals-allowed)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aibtcdev-daos",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aibtcdev-daos",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aibtcdev-daos",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "AI-powered Bitcoin DAOs",
   "type": "module",
   "private": true,

--- a/tests/contracts/agent/aibtc-agent-account.test.ts
+++ b/tests/contracts/agent/aibtc-agent-account.test.ts
@@ -120,6 +120,22 @@ describe(`public functions: ${contractName}`, () => {
   ////////////////////////////////////////
   // deposit-stx() tests
   ////////////////////////////////////////
+  it("deposit-stx() fails if caller is not the owner or agent", () => {
+    // arrange
+    const amount = 1000000; // 1 STX
+
+    // act
+    const receipt = simnet.callPublicFn(
+      contractAddress,
+      "deposit-stx",
+      [Cl.uint(amount)],
+      address3
+    );
+
+    // assert
+    expect(receipt.result).toBeErr(Cl.uint(ErrCode.ERR_OPERATION_NOT_ALLOWED));
+  });
+
   it("deposit-stx() succeeds and deposits STX to the agent account", () => {
     // arrange
     const agentAccountBalances = getBalancesForPrincipal(contractAddress);
@@ -176,6 +192,22 @@ describe(`public functions: ${contractName}`, () => {
   ////////////////////////////////////////
   // deposit-ft() tests
   ////////////////////////////////////////
+  it("deposit-ft() fails if caller is not the owner or agent", () => {
+    // arrange
+    const amount = 10000000;
+
+    // act
+    const receipt = simnet.callPublicFn(
+      contractAddress,
+      "deposit-ft",
+      [Cl.principal(SBTC_CONTRACT), Cl.uint(amount)],
+      address3
+    );
+
+    // assert
+    expect(receipt.result).toBeErr(Cl.uint(ErrCode.ERR_OPERATION_NOT_ALLOWED));
+  });
+
   it("deposit-ft() fails if contract is not approved", () => {
     // arrange
     const amount = 10000000;


### PR DESCRIPTION
Great idea from @rapha-btc, if we restrict the deposit functions to match the tx-sender of the user or agent wallet, then we can safely use wrapper functions in things like the DEX to help user deposit into agent accounts.