### PR TITLE
Add agent account and known info

### DIFF
--- a/@aibtc/types/package-lock.json
+++ b/@aibtc/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aibtc/types",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aibtc/types",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.3"

--- a/@aibtc/types/package.json
+++ b/@aibtc/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aibtc/types",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript types for AIBTC",
   "type": "module",
   "main": "dist/index.js",

--- a/@aibtc/types/src/agent-account-types.ts
+++ b/@aibtc/types/src/agent-account-types.ts
@@ -53,37 +53,14 @@ export interface AgentAccountPermissions {
 }
 
 /**
- * Defines the default permissions for an agent account on each network.
+ * Defines the default permissions for an agent account.
  * These values correspond to the initial data-var values in the contract.
  */
-export const AGENT_ACCOUNT_DEFAULT_PERMISSIONS: Record<
-  StacksNetworkName,
-  AgentAccountPermissions
-> = {
-  mainnet: {
-    canDeposit: true,
-    canUseProposals: true,
-    canApproveRevokeContracts: true,
-    canBuySell: false,
-  },
-  testnet: {
-    canDeposit: true,
-    canUseProposals: true,
-    canApproveRevokeContracts: true,
-    canBuySell: false,
-  },
-  devnet: {
-    canDeposit: true,
-    canUseProposals: true,
-    canApproveRevokeContracts: true,
-    canBuySell: false,
-  },
-  mocknet: {
-    canDeposit: true,
-    canUseProposals: true,
-    canApproveRevokeContracts: true,
-    canBuySell: false,
-  },
+export const AGENT_ACCOUNT_DEFAULT_PERMISSIONS: AgentAccountPermissions = {
+  canDeposit: true,
+  canUseProposals: true,
+  canApproveRevokeContracts: true,
+  canBuySell: false,
 };
 
 /**
@@ -142,14 +119,11 @@ export function getAgentAccountApprovalType(typeInput: string | number): number 
 }
 
 /**
- * Retrieves the default agent permissions for a given network.
- * @param network - The Stacks network name.
- * @returns The default permissions for that network.
+ * Retrieves the default agent permissions.
+ * @returns The default permissions.
  */
-export function getAgentAccountDefaultPermissions(
-  network: StacksNetworkName
-): AgentAccountPermissions {
-  return AGENT_ACCOUNT_DEFAULT_PERMISSIONS[network];
+export function getAgentAccountDefaultPermissions(): AgentAccountPermissions {
+  return AGENT_ACCOUNT_DEFAULT_PERMISSIONS;
 }
 
 /**

--- a/@aibtc/types/src/agent-account-types.ts
+++ b/@aibtc/types/src/agent-account-types.ts
@@ -1,3 +1,5 @@
+import { StacksNetworkName } from "@stacks/network";
+
 /**
  * @file Defines types and helper functions for AIBTC Agent Account contract interactions.
  * @packageDocumentation
@@ -20,6 +22,80 @@ export const AGENT_ACCOUNT_APPROVAL_TYPES = {
  */
 export type AgentAccountApprovalType =
   keyof typeof AGENT_ACCOUNT_APPROVAL_TYPES;
+
+/**
+ * Represents the response from the `get-configuration` function in the `aibtc-agent-account` contract.
+ */
+export interface AgentAccountConfiguration {
+  account: string;
+  agent: string;
+  owner: string;
+  sbtc: string;
+}
+
+/**
+ * Represents the response from the `get-approval-types` function in the `aibtc-agent-account` contract.
+ */
+export interface AgentAccountApprovalTypes {
+  proposalVoting: bigint;
+  swap: bigint;
+  token: bigint;
+}
+
+/**
+ * Represents the response from the `get-agent-permissions` function in the `aibtc-agent-account` contract.
+ */
+export interface AgentAccountPermissions {
+  canDeposit: boolean;
+  canUseProposals: boolean;
+  canApproveRevokeContracts: boolean;
+  canBuySell: boolean;
+}
+
+/**
+ * Defines the default permissions for an agent account on each network.
+ * These values correspond to the initial data-var values in the contract.
+ */
+export const AGENT_ACCOUNT_DEFAULT_PERMISSIONS: Record<
+  StacksNetworkName,
+  AgentAccountPermissions
+> = {
+  mainnet: {
+    canDeposit: true,
+    canUseProposals: true,
+    canApproveRevokeContracts: true,
+    canBuySell: false,
+  },
+  testnet: {
+    canDeposit: true,
+    canUseProposals: true,
+    canApproveRevokeContracts: true,
+    canBuySell: false,
+  },
+  devnet: {
+    canDeposit: true,
+    canUseProposals: true,
+    canApproveRevokeContracts: true,
+    canBuySell: false,
+  },
+  mocknet: {
+    canDeposit: true,
+    canUseProposals: true,
+    canApproveRevokeContracts: true,
+    canBuySell: false,
+  },
+};
+
+/**
+ * Defines the default deployer principal for an agent account on each network.
+ */
+export const AGENT_ACCOUNT_DEFAULT_DEPLOYER: Record<StacksNetworkName, string> =
+  {
+    mainnet: "SP2Z94F6QX847PMXTPJJ2ZCCN79JZDW3PJ4E6ZABY",
+    testnet: "ST2Q77H5HHT79JK4932JCFDX4VY6XA3Y1F61A25CD",
+    devnet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+    mocknet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+  };
 
 /**
  * Validates and converts a user-provided approval type (string or number) into the correct numeric value.
@@ -63,4 +139,26 @@ export function getAgentAccountApprovalType(typeInput: string | number): number 
   }
 
   return numericType;
+}
+
+/**
+ * Retrieves the default agent permissions for a given network.
+ * @param network - The Stacks network name.
+ * @returns The default permissions for that network.
+ */
+export function getAgentAccountDefaultPermissions(
+  network: StacksNetworkName
+): AgentAccountPermissions {
+  return AGENT_ACCOUNT_DEFAULT_PERMISSIONS[network];
+}
+
+/**
+ * Retrieves the default deployer address for an agent account for a given network.
+ * @param network - The Stacks network name.
+ * @returns The default deployer address for that network.
+ */
+export function getAgentAccountDefaultDeployer(
+  network: StacksNetworkName
+): string {
+  return AGENT_ACCOUNT_DEFAULT_DEPLOYER[network];
 }

--- a/@aibtc/types/src/index.ts
+++ b/@aibtc/types/src/index.ts
@@ -49,6 +49,29 @@ export type { ContractType, ContractSubtype, AllContractSubtypes };
 export { CONTRACT_NAMES, CONTRACT_TYPES, CONTRACT_SUBTYPES };
 
 /**
+ * Known addresses and traits
+ * These are used to define the known addresses and traits for each network.
+ */
+import type { KnownAddresses } from "../../../utilities/known-addresses";
+import {
+  getKnownAddresses,
+  getKnownAddress,
+} from "../../../utilities/known-addresses";
+import type { KnownTraits } from "../../../utilities/known-traits";
+import {
+  getKnownTraits,
+  getTraitReference,
+} from "../../../utilities/known-traits";
+
+export type { KnownAddresses, KnownTraits };
+export {
+  getKnownAddresses,
+  getKnownAddress,
+  getKnownTraits,
+  getTraitReference,
+};
+
+/**
  * API response types
  * These are used to define the types of responses that can be returned by the API.
  */

--- a/@aibtc/types/src/index.ts
+++ b/@aibtc/types/src/index.ts
@@ -157,11 +157,32 @@ export {
  * Agent Account Types
  * These types are used for interacting with the AIBTC Agent Account contract.
  */
-import type { AgentAccountApprovalType } from "./agent-account-types";
+import type {
+  AgentAccountApprovalType,
+  AgentAccountConfiguration,
+  AgentAccountApprovalTypes,
+  AgentAccountPermissions,
+} from "./agent-account-types";
 import {
   AGENT_ACCOUNT_APPROVAL_TYPES,
   getAgentAccountApprovalType,
+  AGENT_ACCOUNT_DEFAULT_PERMISSIONS,
+  getAgentAccountDefaultPermissions,
+  AGENT_ACCOUNT_DEFAULT_DEPLOYER,
+  getAgentAccountDefaultDeployer,
 } from "./agent-account-types";
 
-export type { AgentAccountApprovalType };
-export { AGENT_ACCOUNT_APPROVAL_TYPES, getAgentAccountApprovalType };
+export type {
+  AgentAccountApprovalType,
+  AgentAccountConfiguration,
+  AgentAccountApprovalTypes,
+  AgentAccountPermissions,
+};
+export {
+  AGENT_ACCOUNT_APPROVAL_TYPES,
+  getAgentAccountApprovalType,
+  AGENT_ACCOUNT_DEFAULT_PERMISSIONS,
+  getAgentAccountDefaultPermissions,
+  AGENT_ACCOUNT_DEFAULT_DEPLOYER,
+  getAgentAccountDefaultDeployer,
+};

--- a/durable-objects/aibtc-mcp-do.ts
+++ b/durable-objects/aibtc-mcp-do.ts
@@ -2,14 +2,16 @@ import { z } from "zod";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ContractGeneratorService } from "../src/services/contract-generator";
+import { CloudflareBindings } from "../src/cf-types";
 import { ContractRegistry } from "../utilities/contract-registry";
+import { DurableObjectState } from "@cloudflare/workers-types";
 
 export class AIBTC_MCP_DO extends McpAgent {
   server = new McpServer({ name: "AIBTC", version: "1.0.0" });
   private registry: ContractRegistry;
   private generatorService: ContractGeneratorService;
 
-  constructor(state: DurableObjectState, env: Env) {
+  constructor(state: DurableObjectState, env: CloudflareBindings) {
     super(state, env);
     this.registry = new ContractRegistry();
     this.generatorService = new ContractGeneratorService();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.37.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.16.0",
+        "@modelcontextprotocol/sdk": "^1.17.0",
         "agents": "^0.0.109",
-        "hono": "^4.8.5"
+        "hono": "^4.8.9"
       },
       "devDependencies": {
-        "@aibtc/types": "^0.11.0",
-        "@cloudflare/vite-plugin": "^1.9.6",
-        "@cloudflare/workers-types": "^4.20250719.0",
+        "@aibtc/types": "^0.12.0",
+        "@cloudflare/vite-plugin": "^1.10.1",
+        "@cloudflare/workers-types": "^4.20250726.0",
         "@hirosystems/clarinet-sdk": "^3.3.0",
         "@hono/vite-build": "^1.6.2",
         "@stacks/transactions": "^7.1.0",
@@ -29,7 +29,7 @@
         "vitest": "^3.2.4",
         "vitest-environment-clarinet": "^2.3.0",
         "workers-mcp": "^0.0.13",
-        "wrangler": "^4.25.0",
+        "wrangler": "^4.26.0",
         "zod": "^3.25.76"
       }
     },
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@aibtc/types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/types/-/types-0.11.0.tgz",
-      "integrity": "sha512-BnGiHaPkLd4RJwPG0PBEO5Lj4wuJmGwOdLklN6aNkggb/0FmL+fHH9zMD+ZO1OefgdrPON/drL3bJN2JjOeFUA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/types/-/types-0.12.0.tgz",
+      "integrity": "sha512-UnxG2hJHVG6hP4NIop+GqI2E/PlwNPnN87q28IZF5cgclFatXw79lFUlpm7T3ILkif12/khCQBnpipn892+hDQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -218,14 +218,14 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.3.tgz",
-      "integrity": "sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.4.1.tgz",
+      "integrity": "sha512-70mk5GPv+ozJ5XcIhFpq4ps7HvQYu+As7vwasUy9LcBadsTcWA2iFis/7aFJmQehfKerDwVOHfMYpgTTC+u24Q==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.17",
-        "workerd": "^1.20250508.0"
+        "workerd": "^1.20250521.0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -234,26 +234,26 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.9.6.tgz",
-      "integrity": "sha512-8sUMJVHD3VY8J4HwovoKN87DP9zfV/jxhY7oAYZJO1MuiWJ0vZE614vyT3tMElRwu6d64yx5NTUwRGzWXarYPg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.10.1.tgz",
+      "integrity": "sha512-XXaEe1RVFp2cKHTkaK3JPurdvii44n2c2veyWEZl7l6U1xSqOuXkOfs2flDgX+74w7bbknvd8wLCXCTHRxXuBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cloudflare/unenv-preset": "2.3.3",
+        "@cloudflare/unenv-preset": "2.4.1",
         "@mjackson/node-fetch-server": "^0.6.1",
         "@rollup/plugin-replace": "^6.0.1",
         "get-port": "^7.1.0",
-        "miniflare": "4.20250712.0",
+        "miniflare": "4.20250712.2",
         "picocolors": "^1.1.1",
         "tinyglobby": "^0.2.12",
         "unenv": "2.0.0-rc.17",
-        "wrangler": "4.25.0",
+        "wrangler": "4.26.0",
         "ws": "8.18.0"
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0",
-        "wrangler": "^4.25.0"
+        "wrangler": "^4.26.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250719.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250719.0.tgz",
-      "integrity": "sha512-tSc2FM2QPWA8ZmDniQXz+4qVKuf8zrwVwqlkXxxGBsQHxTpcukuMibYcYWxwonzbzK7YzSug+iena2F8gGOuOw==",
+      "version": "4.20250726.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250726.0.tgz",
+      "integrity": "sha512-NtM1yVBKJFX4LgSoZkVU0EDhWWvSb1vt6REO+uMYZRgx1HAfQz9GDN6bBB0B+fm2ZIxzt6FzlDbmrXpGJ2M/4Q==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1262,9 +1262,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
-      "integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.0.tgz",
+      "integrity": "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.5.tgz",
-      "integrity": "sha512-Up2cQbtNz1s111qpnnECdTGqSIUIhZJMLikdKkshebQSEBcoUKq6XJayLGqSZWidiH0zfHRCJqFu062Mz5UuRA==",
+      "version": "4.8.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.9.tgz",
+      "integrity": "sha512-ERIxkXMRhUxGV7nS/Af52+j2KL60B1eg+k6cPtgzrGughS+espS9KQ7QO0SMnevtmRlBfAcN0mf1jKtO6j/doA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3970,9 +3970,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250712.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250712.0.tgz",
-      "integrity": "sha512-o7zYqG4pMi3gQTjiGhgZ82bQfexNwK+bzAaNlu8f7m3Kra4DcU5LC9nznfq2rfIBnUnMgwtU2VUfMlN1TuI8Og==",
+      "version": "4.20250712.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250712.2.tgz",
+      "integrity": "sha512-cZ8WyQBwqfjYLjd61fDR4/j0nAVbjB3Wxbun/brL9S5FAi4RlTR0LyMTKsIVA0s+nL4Pg9VjVMki4M/Jk2cz+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5809,17 +5809,17 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.25.0.tgz",
-      "integrity": "sha512-SepXQbzWkdp0O7qAx3i0go+fw5I0VkDqLV2G3ewbffO5k8kpvuCkhalS23KO+7+o8+Oa3vfC7x+16IL3rj2n4w==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.26.0.tgz",
+      "integrity": "sha512-EXuwyWlgYQZv6GJlyE0lVGk9hHqASssuECECT1XC5aIijTwNLQhsj/TOZ0hKSFlMbVr1E+OAdevAxd0kaF4ovA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.3.3",
+        "@cloudflare/unenv-preset": "2.4.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20250712.0",
+        "miniflare": "4.20250712.2",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.17",
         "workerd": "1.20250712.0"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.16.0",
+    "@modelcontextprotocol/sdk": "^1.17.0",
     "agents": "^0.0.109",
-    "hono": "^4.8.5"
+    "hono": "^4.8.9"
   },
   "devDependencies": {
-    "@aibtc/types": "^0.11.0",
-    "@cloudflare/vite-plugin": "^1.9.6",
-    "@cloudflare/workers-types": "^4.20250719.0",
+    "@aibtc/types": "^0.12.0",
+    "@cloudflare/vite-plugin": "^1.10.1",
+    "@cloudflare/workers-types": "^4.20250726.0",
     "@hirosystems/clarinet-sdk": "^3.3.0",
     "@hono/vite-build": "^1.6.2",
     "@stacks/transactions": "^7.1.0",
@@ -42,7 +42,7 @@
     "vitest": "^3.2.4",
     "vitest-environment-clarinet": "^2.3.0",
     "workers-mcp": "^0.0.13",
-    "wrangler": "^4.25.0",
+    "wrangler": "^4.26.0",
     "zod": "^3.25.76"
   }
 }

--- a/utilities/known-addresses.ts
+++ b/utilities/known-addresses.ts
@@ -63,13 +63,11 @@ const ADDRESSES: Record<StacksNetworkName, KnownAddresses> = {
 } as const;
 
 // helper to get known addresses for a network
-// TODO: export this in package!
 export function getKnownAddresses(network: StacksNetworkName): KnownAddresses {
   return ADDRESSES[network];
 }
 
 // helper to get a specific address
-// TODO: export this in package!
 export function getKnownAddress(
   network: StacksNetworkName,
   address: keyof KnownAddresses

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ command, isSsrBuild }) => {
     ],
     build: {
       rollupOptions: {
-        external: ["cloudflare:workers"],
+        external: ["cloudflare:workers", "cloudflare:email"],
       },
     },
   };


### PR DESCRIPTION
This pull request introduces new types and helpers for Agent Accounts and improves the accessibility of shared utilities.

Summary of Changes related to the Agent Account:

- Added Agent Account Types (`AgentAccountConfiguration`, `AgentAccountApprovalTypes`, `AgentAccountPermissions`)
 - Added Agent Account Helpers: Implemented helper functions like `getAgentAccountApprovalType` and `getAgentAccountDefaultPermissions` to work with the new agent account types.
 - Added Default Permissions: Added a constant for agent account default permissions.                                                                                                                    

Additional changes:

 - Exported Utility Functions: Exposed helper functions for retrieving known addresses and known traits for broader use.